### PR TITLE
Add formatter and utility tests

### DIFF
--- a/tests/unit/chainHelper.test.js
+++ b/tests/unit/chainHelper.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  transformToDebankChainName,
+  normalizeChainName,
+} from "../../src/utils/chainHelper.js";
+
+test("transformToDebankChainName maps known chains", () => {
+  assert.equal(transformToDebankChainName("ethereum"), "eth");
+  assert.equal(transformToDebankChainName("arbitrum one"), "arb");
+  assert.equal(transformToDebankChainName("base"), "base");
+  assert.equal(transformToDebankChainName("unknown"), "unknown");
+});
+
+test("normalizeChainName lowercases and trims suffixes", () => {
+  assert.equal(normalizeChainName("Arbitrum One"), "arbitrum");
+  assert.equal(normalizeChainName("OP Mainnet"), "op");
+  assert.equal(normalizeChainName("  Base   "), "base");
+  assert.equal(normalizeChainName(null), "");
+});

--- a/tests/unit/formatters.test.js
+++ b/tests/unit/formatters.test.js
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatSmallNumber,
+  formatBalance,
+  formatEthAmount,
+  formatSmallCurrency,
+} from "../../src/utils/formatters.js";
+
+test("formatSmallNumber handles various ranges", () => {
+  assert.equal(formatSmallNumber(0), "0");
+  assert.equal(formatSmallNumber(0.0000005), "< 0.000001");
+  assert.equal(formatSmallNumber(0.005), "0.005000");
+  assert.equal(formatSmallNumber(0.5), "0.5000");
+  assert.equal(formatSmallNumber(50), "50.00");
+  assert.equal(formatSmallNumber(150), "150");
+});
+
+test("formatBalance formats dollar amounts", () => {
+  assert.equal(formatBalance(0), "$0.00");
+  assert.equal(formatBalance(0.005), "< $0.01");
+  assert.equal(formatBalance(1.234), "$1.23");
+});
+
+test("formatEthAmount handles precision thresholds", () => {
+  assert.equal(formatEthAmount(0), "0 ETH");
+  assert.equal(formatEthAmount(0.00005), "< 0.0001 ETH");
+  assert.equal(formatEthAmount(0.005), "0.00500000 ETH");
+  assert.equal(formatEthAmount(0.5), "0.5000 ETH");
+  assert.equal(formatEthAmount(5), "5.0000 ETH");
+});
+
+test("formatSmallCurrency handles thresholds and negatives", () => {
+  assert.equal(formatSmallCurrency(0), "0");
+  assert.equal(formatSmallCurrency(0.005), "< $0.0100");
+  assert.equal(formatSmallCurrency(-0.005), "-< $0.0100");
+  assert.equal(formatSmallCurrency(1.234), "$1.23");
+  assert.equal(formatSmallCurrency(-2.5), "-$2.50");
+});

--- a/tests/unit/tokenUtils.test.js
+++ b/tests/unit/tokenUtils.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getTokenSymbol,
+  getFilteredAndSortedTokens,
+  calculateTotalTokenValue,
+} from "../../src/utils/tokenUtils.js";
+
+test("getTokenSymbol prioritizes optimized symbol", () => {
+  assert.equal(
+    getTokenSymbol({ optimized_symbol: "WBTC", symbol: "BTC" }),
+    "WBTC"
+  );
+  assert.equal(getTokenSymbol({ symbol: "ETH" }), "ETH");
+  assert.equal(getTokenSymbol({}), "UNKNOWN");
+});
+
+test("getFilteredAndSortedTokens filters invalid tokens and sorts by value", () => {
+  const tokens = [
+    { amount: 1, price: 10 }, // value 10
+    { amount: 0, price: 10 }, // filtered out (amount)
+    { amount: 1, price: 0 }, // filtered out (price)
+    { amount: 2, price: 5 }, // value 10
+    { amount: 1, price: 20 }, // value 20
+  ];
+  const result = getFilteredAndSortedTokens(tokens);
+  assert.equal(result.length, 3);
+  assert.deepEqual(
+    result.map(t => t.amount * t.price),
+    [20, 10, 10]
+  );
+});
+
+test("calculateTotalTokenValue sums token values", () => {
+  const tokens = [
+    { amount: 1, price: 10 },
+    { amount: 2, price: 5 },
+  ];
+  assert.equal(calculateTotalTokenValue(tokens), 20);
+  assert.equal(calculateTotalTokenValue(null), 0);
+});


### PR DESCRIPTION
## Summary
- add unit tests for number and currency formatters
- add unit tests for chain helpers and token utilities

## Testing
- `node --test tests/unit`
- `npm run lint`
- `npm test` *(fails: Playwright could not run tests; see HTML report notice)*

------
https://chatgpt.com/codex/tasks/task_e_68956a58077c8325ba669aee46c84095