### PR TITLE
docs: add Claude guide and AI collaboration notes

### DIFF
--- a/.serena/memories/architecture_overview.md
+++ b/.serena/memories/architecture_overview.md
@@ -136,3 +136,8 @@ SwapPage/
 3. **Hook-First Design**: Business logic encapsulated in custom hooks
 4. **Type-Driven Development**: TypeScript-first approach with strict typing
 5. **Configuration-Based Flexibility**: Environment and chain configuration externalized
+
+## 🤖 AI Development Aids
+
+- `.serena/` stores project memories and configuration for the Serena agent.
+- `Claude.md` and `.claude/commands/` document workflows for the Claude agent.

--- a/.serena/memories/component-inventory.md
+++ b/.serena/memories/component-inventory.md
@@ -121,14 +121,16 @@
 - **`VersionInfo`** - App version display
 - **`MenuSection`** - Settings menu section with items
 
-## 🌟 Feature-Specific Tabs (`src/components/MoreTab/`)
+## 🌟 Analytics & Community Support (`src/components/MoreTab/`)
 
-### **More Tab Components**
+### **Shared Components**
 
 - **`SocialLinks`** - Social media and external links
 - **`PodcastSection`** - Podcast links and media
 - **`AnalyticsDashboard`** - Advanced analytics visualization
 - **`CommunityStats`** - Community metrics and statistics
+
+These legacy-named components support the Analytics and Community tabs.
 
 ## 🎓 Onboarding (`src/components/Onboarding/`)
 

--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,14 @@
+# Claude Guide
+
+This repository provides resources for working with Anthropic's Claude agent.
+
+## Project Orientation
+
+- Review `.serena/memories/architecture_overview.md` and `.serena/memories/component-inventory.md`
+  for an overview of the system and components.
+- Use `rg` for code searches instead of recursive `grep`.
+- Run `npm test` and `npm run lint` to verify changes before committing.
+
+## Commands
+
+Custom command definitions for Claude live in `.claude/commands/`.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ execution.
 - 🥧 **Asset Categories** - Visual pie chart for BTC, ETH, STABLECOIN, ALTCOIN categories
 - 🔍 **Detailed Analytics** - Expandable asset details with pool information and APR
 - 🔄 **Intent-Based Actions** - ZapIn, ZapOut, and Optimize operations
-- 🚀 **Investment Hub** - Curated DeFi strategies and opportunities
-- ⚙️ **Settings & More** - Comprehensive settings and help section
+- 🧑‍🤝‍🧑 **Community Hub** - Stats, podcasts, and social links
+- ⚙️ **Settings** - Comprehensive preferences and help section
 - 📱 **Mobile Responsive** - Optimized for all screen sizes
 - ⚡ **Performance** - Built with Next.js 15 and Turbopack
 - 🎭 **Animations** - Smooth Framer Motion transitions
@@ -43,7 +43,7 @@ The dashboard displays key portfolio metrics:
 
 - **Desktop**: Left sidebar with detailed navigation
 - **Mobile**: Bottom tab bar with swipe gestures
-- **Three main sections**: Portfolio, Invest, More
+- **Sections**: Portfolio, Analytics, Community, Airdrop, Settings
 
 ### 💼 Portfolio Tab (Wallet Interface)
 
@@ -59,17 +59,24 @@ The dashboard displays key portfolio metrics:
   - APR rates and asset types
   - Pool performance metrics
 
-### 🚀 Invest Tab
+### 📊 Analytics Tab
 
-- **Strategy Discovery**: Curated DeFi investment opportunities
-- **Risk Assessment**: Low, Medium, High risk categorization
-- **Performance Metrics**: APR, TVL, and strategy details
+- **Performance Charts**: Historical portfolio analytics and metrics
+- **Dashboards**: Interactive analytics dashboard components
 
-### ⚙️ More Tab
+### 🧑‍🤝‍🧑 Community Tab
 
-- **Account Settings**: Preferences and configuration
+- **Community Stats**: Ecosystem metrics and engagement
+- **Resources**: Podcast links and social media connections
+
+### 🎁 Airdrop Tab
+
+- **Rewards Overview**: Token reward programs for early users
+
+### ⚙️ Settings Tab
+
+- **Account Preferences**: Configuration options and personalization
 - **Help & Support**: Documentation and community links
-- **About**: App information and social connections
 
 ## Quick Actions
 
@@ -122,3 +129,12 @@ Following the Zap Pilot design language:
 - Safari 14+
 - Mobile Safari 14+
 - Chrome Mobile 88+
+
+## AI Collaboration
+
+This repository includes configuration and guidance for automated agents:
+
+- `.serena/` holds project memories and configuration for the Serena agent.
+- `.claude/` and `Claude.md` document workflows and commands for Anthropic's Claude.
+
+Keep these resources updated as the codebase evolves.


### PR DESCRIPTION
## Summary
- document AI collaboration resources in README
- add a Claude guide and link to command definitions
- note AI aid files in Serena memories
- refresh navigation docs and legacy component references

## Testing
- `npm test` *(fails: Error while requesting resource fonts.googleapis.com; 12 failed tests)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68957aec0588832592a17e6870e50aa4